### PR TITLE
Java8 datetime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
@@ -38,6 +39,7 @@ android {
         versionCode = 3200
         versionName = "32.0-alpha1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled = true
     }
 
     buildTypes {
@@ -93,6 +95,8 @@ dependencies {
     val mockitoVersion = "3.7.7"
     val kotlinxVersion = "1.4.2"
     val daggerVersion = "2.31.2"
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
     // tests
     testImplementation("junit:junit:4.13.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,10 +141,10 @@ dependencies {
     // finding a name for a feature without a name tag
     implementation("de.westnordost:osmfeatures-android:2.1")
     // talking with the OSM API
-    implementation("de.westnordost:osmapi-map:1.5")
-    implementation("de.westnordost:osmapi-changesets:1.6")
-    implementation("de.westnordost:osmapi-notes:1.4")
-    implementation("de.westnordost:osmapi-user:1.5")
+    implementation("de.westnordost:osmapi-map:2.0")
+    implementation("de.westnordost:osmapi-changesets:2.0")
+    implementation("de.westnordost:osmapi-notes:2.0")
+    implementation("de.westnordost:osmapi-user:2.0")
     implementation("com.squareup.okhttp3:okhttp:3.12.12")
     implementation("se.akerfeldt:okhttp-signpost:1.1.0")
 

--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -18,7 +18,7 @@ import de.westnordost.streetcomplete.ktx.tryStartActivity
 import de.westnordost.streetcomplete.util.sendEmail
 import de.westnordost.streetcomplete.view.ListAdapter
 import kotlinx.android.synthetic.main.cell_labeled_icon_select_right.view.*
-import java.util.*
+import java.util.Locale
 
 /** Shows the about screen */
 class AboutFragment : PreferenceFragmentCompat() {

--- a/app/src/main/java/de/westnordost/streetcomplete/controls/IconsDownloadProgressView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/controls/IconsDownloadProgressView.kt
@@ -8,7 +8,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.toPx
 import de.westnordost.streetcomplete.view.CircularMaskFrameLayout
 import kotlinx.android.synthetic.main.view_icons_download_progress.view.*
-import java.util.*
+import java.util.Queue
+import java.util.LinkedList
 
 /** view that shows a queue of IconProgressViews moving in from the right and moving out to the
  *  left when they are done */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmApiModule.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.data
 import dagger.Module
 import dagger.Provides
 import de.westnordost.osmapi.OsmConnection
+import de.westnordost.osmapi.user.UserApi
 import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApi
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataApiImpl
@@ -27,7 +28,7 @@ object OsmApiModule {
         return OsmConnection(OSM_API_URL, ApplicationConstants.USER_AGENT, consumer)
     }
 
-    @Provides fun userDao(osm: OsmConnection): UserApi = UserApi(osm)
+    @Provides fun userApi(osm: OsmConnection): UserApi = UserApi(osm)
 
     @Provides fun notesApi(osm: OsmConnection): NotesApi = NotesApiImpl(osm)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmapiTypealiases.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmapiTypealiases.kt
@@ -1,7 +1,0 @@
-package de.westnordost.streetcomplete.data
-
-import de.westnordost.osmapi.user.PermissionsDao
-import de.westnordost.osmapi.user.UserDao
-
-typealias PermissionsApi = PermissionsDao
-typealias UserApi = UserDao

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpression.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.elementfilter.ElementsTypeFilter.RELAT
 import de.westnordost.streetcomplete.data.elementfilter.filters.ElementFilter
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
-import java.util.*
+import java.util.EnumSet
 
 /** Represents a parse result of a string in filter syntax, i.e.
  *  "ways with (highway = residential or highway = tertiary) and !name"  */
@@ -22,7 +22,6 @@ class ElementFilterExpression(
         ElementType.NODE -> elementsTypes.contains(NODES)
         ElementType.WAY -> elementsTypes.contains(WAYS)
         ElementType.RELATION -> elementsTypes.contains(RELATIONS)
-        else -> false
     }
 
     /** returns this expression as a Overpass query string */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParser.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersParser.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDate
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import java.lang.NumberFormatException
 import java.text.ParseException
-import java.util.*
+import java.util.EnumSet
 import kotlin.collections.ArrayList
 import kotlin.math.min
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/OverpassQueryCreator.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/OverpassQueryCreator.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.data.elementfilter
 import de.westnordost.streetcomplete.data.elementfilter.ElementsTypeFilter.*
 import de.westnordost.streetcomplete.data.elementfilter.filters.ElementFilter
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import java.util.*
+import java.util.EnumSet
 
 /** Create an overpass query from the given element filter expression */
 class OverpassQueryCreator(

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareDateTagValue.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareDateTagValue.kt
@@ -5,10 +5,10 @@ import de.westnordost.streetcomplete.data.elementfilter.quoteIfNecessary
 import de.westnordost.streetcomplete.data.meta.toCheckDate
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import java.util.*
+import java.time.LocalDate
 
 abstract class CompareDateTagValue(val key: String, val dateFilter: DateFilter): ElementFilter {
-    val date: Date get() = dateFilter.date
+    val date: LocalDate get() = dateFilter.date
 
     override fun toOverpassQLString() : String {
         val strVal = date.toCheckDateString()
@@ -22,6 +22,6 @@ abstract class CompareDateTagValue(val key: String, val dateFilter: DateFilter):
         return compareTo(tagValue)
     }
 
-    abstract fun compareTo(tagValue: Date): Boolean
+    abstract fun compareTo(tagValue: LocalDate): Boolean
     abstract val operator: String
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareElementAge.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareElementAge.kt
@@ -2,10 +2,12 @@ package de.westnordost.streetcomplete.data.elementfilter.filters
 
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import java.util.*
+import de.westnordost.streetcomplete.ktx.toLocalDate
+import java.time.Instant
+import java.time.LocalDate
 
 abstract class CompareElementAge(private val dateFilter: DateFilter) : ElementFilter {
-    val date: Date get() = dateFilter.date
+    val date: LocalDate get() = dateFilter.date
 
     override fun toOverpassQLString() =
         "(if: date(timestamp()) " + operator + " date('" + date.toCheckDateString() + "'))"
@@ -14,9 +16,9 @@ abstract class CompareElementAge(private val dateFilter: DateFilter) : ElementFi
 
     override fun matches(obj: Element?): Boolean {
         val timestampEdited = obj?.timestampEdited ?: return false
-        return compareTo(Date(timestampEdited))
+        return compareTo(Instant.ofEpochMilli(timestampEdited).toLocalDate())
     }
 
-    abstract fun compareTo(tagValue: Date): Boolean
+    abstract fun compareTo(tagValue: LocalDate): Boolean
     abstract val operator: String
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareTagAge.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/CompareTagAge.kt
@@ -4,10 +4,12 @@ import de.westnordost.streetcomplete.data.meta.getLastCheckDateKeys
 import de.westnordost.streetcomplete.data.meta.toCheckDate
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
-import java.util.*
+import de.westnordost.streetcomplete.ktx.toLocalDate
+import java.time.Instant
+import java.time.LocalDate
 
 abstract class CompareTagAge(val key: String, val dateFilter: DateFilter) : ElementFilter {
-    val date: Date get() = dateFilter.date
+    val date: LocalDate get() = dateFilter.date
 
     override fun toOverpassQLString(): String {
         val dateStr = date.toCheckDateString()
@@ -20,14 +22,13 @@ abstract class CompareTagAge(val key: String, val dateFilter: DateFilter) : Elem
 
     override fun matches(obj: Element?): Boolean {
         val timestampEdited = obj?.timestampEdited ?: return false
-
-        if (compareTo(Date(timestampEdited))) return true
+        if (compareTo(Instant.ofEpochMilli(timestampEdited).toLocalDate())) return true
 
         return getLastCheckDateKeys(key)
             .mapNotNull { obj.tags[it]?.toCheckDate() }
             .any { compareTo(it) }
     }
 
-    abstract fun compareTo(tagValue: Date): Boolean
+    abstract fun compareTo(tagValue: LocalDate): Boolean
     abstract val operator: String
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementNewerThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementNewerThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** newer 2002-11-11 / newer today - 1 year */
 class ElementNewerThan(dateFilter: DateFilter) : CompareElementAge(dateFilter) {
-    override fun compareTo(tagValue: Date) = tagValue > date
+    override fun compareTo(tagValue: LocalDate) = tagValue > date
     override val operator = ">"
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementOlderThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/ElementOlderThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** older 2002-11-11 / older today - 1 year */
 class ElementOlderThan(dateFilter: DateFilter) : CompareElementAge(dateFilter) {
-    override fun compareTo(tagValue: Date) = tagValue < date
+    override fun compareTo(tagValue: LocalDate) = tagValue < date
     override val operator = "<"
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key >= date */
 class HasDateTagGreaterOrEqualThan(key: String, dateFilter: DateFilter): CompareDateTagValue(key, dateFilter) {
     override val operator = ">="
-    override fun compareTo(tagValue: Date) = tagValue >= date
+    override fun compareTo(tagValue: LocalDate) = tagValue >= date
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key > date */
 class HasDateTagGreaterThan(key: String, dateFilter: DateFilter): CompareDateTagValue(key, dateFilter) {
     override val operator = ">"
-    override fun compareTo(tagValue: Date) = tagValue > date
+    override fun compareTo(tagValue: LocalDate) = tagValue > date
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key <= date */
 class HasDateTagLessOrEqualThan(key: String, dateFilter: DateFilter): CompareDateTagValue(key, dateFilter) {
     override val operator = "<="
-    override fun compareTo(tagValue: Date) = tagValue <= date
+    override fun compareTo(tagValue: LocalDate) = tagValue <= date
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key < date */
 class HasDateTagLessThan(key: String, dateFilter: DateFilter): CompareDateTagValue(key, dateFilter) {
     override val operator = "<"
-    override fun compareTo(tagValue: Date) = tagValue < date
+    override fun compareTo(tagValue: LocalDate) = tagValue < date
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/RelativeDate.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/RelativeDate.kt
@@ -1,17 +1,23 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.math.absoluteValue
 
 interface DateFilter {
-    val date: Date
+    val date: LocalDate
 }
 
 /** A date relative to (start of) today (positive: future, negative: past) */
 class RelativeDate(val deltaDays: Float): DateFilter {
-    override val date: Date get() {
-        val cal: Calendar = Calendar.getInstance()
-        cal.add(Calendar.SECOND, (deltaDays * 24 * 60 * 60 * MULTIPLIER).toInt())
-        return cal.time
+    override val date: LocalDate get() {
+        val now = LocalDateTime.now()
+        val plusHours = (deltaDays * MULTIPLIER * 24).toLong()
+        val relativeDateTime = (
+            if (plusHours > 0) now.plusHours(plusHours)
+            else now.minusHours(plusHours.absoluteValue)
+        )
+        return relativeDateTime.toLocalDate()
     }
 
     companion object {
@@ -19,4 +25,4 @@ class RelativeDate(val deltaDays: Float): DateFilter {
     }
 }
 
-class FixedDate(override val date: Date): DateFilter
+class FixedDate(override val date: LocalDate): DateFilter

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagNewerThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagNewerThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key newer 2000-02-02 / key newer -8 years */
 class TagNewerThan(key: String, dateFilter: DateFilter) : CompareTagAge(key, dateFilter) {
-    override fun compareTo(tagValue: Date) = tagValue > date
+    override fun compareTo(tagValue: LocalDate) = tagValue > date
     override val operator = ">"
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThan.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/elementfilter/filters/TagOlderThan.kt
@@ -1,9 +1,9 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import java.util.*
+import java.time.LocalDate
 
 /** key older 2000-02-02 / key older -8 years */
 class TagOlderThan(key: String, dateFilter: DateFilter) : CompareTagAge(key, dateFilter) {
-    override fun compareTo(tagValue: Date) = tagValue < date
+    override fun compareTo(tagValue: LocalDate) = tagValue < date
     override val operator = "<"
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManager.kt
@@ -10,8 +10,7 @@ import de.westnordost.streetcomplete.data.osm.edits.upload.LastEditTimeStore
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.ktx.toBcp47LanguageTag
-import java.util.*
-
+import java.util.Locale
 import javax.inject.Inject
 
 /** Manages the creation and reusage of quest-related changesets */

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/AvatarsDownloader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/AvatarsDownloader.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.data.osmnotes
 
 import android.util.Log
-import de.westnordost.streetcomplete.data.UserApi
+import de.westnordost.osmapi.user.UserApi
 import de.westnordost.streetcomplete.ktx.format
 import de.westnordost.streetcomplete.ktx.saveToFile
 import java.io.File

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
@@ -8,7 +8,6 @@ import de.westnordost.streetcomplete.data.osmnotes.NoteController
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditAction.*
 import de.westnordost.streetcomplete.data.user.User
 import de.westnordost.streetcomplete.data.user.UserStore
-import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestController.kt
@@ -18,7 +18,7 @@ import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestContro
 import de.westnordost.streetcomplete.quests.note_discussion.NoteAnswer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.collections.ArrayList

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsDownloader.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsDownloader.kt
@@ -5,13 +5,10 @@ import org.json.JSONObject
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.Instant
 
 /** Downloads statistics from the backend */
 class StatisticsDownloader(private val baseUrl: String) {
-
-    private val lastActivityDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
     fun download(osmUserId: Long): Statistics {
         (URL("$baseUrl?user_id=$osmUserId").openConnection() as HttpURLConnection).run {
@@ -54,7 +51,7 @@ class StatisticsDownloader(private val baseUrl: String) {
         val rank = obj.getInt("rank")
         val daysActive = obj.getInt("daysActive")
         val isAnalyzing = obj.getBoolean("isAnalyzing")
-        val lastUpdate = lastActivityDateFormat.parse(obj.getString("lastUpdate"))!!
-        return Statistics(questTypes, countriesStatistics, rank, daysActive, lastUpdate.time, isAnalyzing)
+        val lastUpdate = Instant.parse(obj.getString("lastUpdate"))!!
+        return Statistics(questTypes, countriesStatistics, rank, daysActive, lastUpdate.toEpochMilli(), isAnalyzing)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/StatisticsUpdater.kt
@@ -5,7 +5,9 @@ import de.westnordost.countryboundaries.CountryBoundaries
 import de.westnordost.countryboundaries.getIds
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.user.achievements.AchievementGiver
-import java.util.*
+import de.westnordost.streetcomplete.ktx.toLocalDate
+import java.time.Instant
+import java.time.LocalDate
 import java.util.concurrent.FutureTask
 import javax.inject.Inject
 import javax.inject.Named
@@ -42,16 +44,11 @@ class StatisticsUpdater @Inject constructor(
         }
 
     private fun updateDaysActive() {
-        val now = Date()
-        val lastUpdateDate = Date(userStore.lastStatisticsUpdate)
+        val today = LocalDate.now()
+        val lastUpdateDate = Instant.ofEpochMilli(userStore.lastStatisticsUpdate).toLocalDate()
 
-        val cal1 = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-        cal1.time = lastUpdateDate
-        val cal2 = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-        cal2.time = now
-
-        userStore.lastStatisticsUpdate = now.time
-        if (!cal1.isSameDay(cal2)) {
+        userStore.lastStatisticsUpdate = Instant.now().toEpochMilli()
+        if (today > lastUpdateDate) {
             userStore.daysActive++
             achievementGiver.updateDaysActiveAchievements()
         }
@@ -103,7 +100,3 @@ class StatisticsUpdater @Inject constructor(
         private const val TAG = "StatisticsUpdater"
     }
 }
-
-private fun Calendar.isSameDay(other: Calendar): Boolean =
-    get(Calendar.DAY_OF_YEAR) == other.get(Calendar.DAY_OF_YEAR) &&
-    get(Calendar.YEAR) == other.get(Calendar.YEAR)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserController.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.data.user
 
 import android.util.Log
 import de.westnordost.osmapi.OsmConnection
-import de.westnordost.streetcomplete.data.UserApi
+import de.westnordost.osmapi.user.UserApi
 import de.westnordost.streetcomplete.data.osmnotes.AvatarsDownloader
 import de.westnordost.streetcomplete.data.user.achievements.*
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/de/westnordost/streetcomplete/edithistory/UndoDialog.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/edithistory/UndoDialog.kt
@@ -38,7 +38,7 @@ import de.westnordost.streetcomplete.view.Text
 import de.westnordost.streetcomplete.view.setText
 import kotlinx.coroutines.*
 import org.sufficientlysecure.htmltextview.HtmlTextView
-import java.util.*
+import java.util.MissingFormatArgumentException
 import java.util.concurrent.FutureTask
 import javax.inject.Inject
 

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/Element.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/Element.kt
@@ -3,7 +3,6 @@ package de.westnordost.streetcomplete.ktx
 import de.westnordost.osmfeatures.GeometryType
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.mapdata.*
-import java.util.*
 
 fun Element.copy(
     newId: Long = id,

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/LocalDate.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/LocalDate.kt
@@ -1,0 +1,13 @@
+package de.westnordost.streetcomplete.ktx
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+fun LocalDate.toInstant() =
+    this.atStartOfDay(ZoneId.systemDefault()).toInstant()
+
+fun LocalDate.toEpochMilli() = this.toInstant().toEpochMilli()
+
+fun Instant.toLocalDate() =
+    this.atZone(ZoneId.systemDefault()).toLocalDate()

--- a/app/src/main/java/de/westnordost/streetcomplete/location/LocationStateButton.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/location/LocationStateButton.kt
@@ -11,7 +11,7 @@ import android.view.View
 import androidx.annotation.Keep
 import androidx.appcompat.widget.AppCompatImageButton
 import de.westnordost.streetcomplete.R
-import java.util.*
+import java.util.Arrays
 
 /**
  * An image button which shows the current location state

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -57,12 +57,12 @@ import kotlinx.android.synthetic.main.fragment_main.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.*
 import javax.inject.Inject
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+import kotlin.random.Random
 
 /** Contains the quests map and the controls for it. */
 class MainFragment : Fragment(R.layout.fragment_main),
@@ -84,8 +84,6 @@ class MainFragment : Fragment(R.layout.fragment_main),
     @Inject internal lateinit var visibleQuestsSource: VisibleQuestsSource
     @Inject internal lateinit var soundFx: SoundFx
     @Inject internal lateinit var prefs: SharedPreferences
-
-    private val random = Random()
 
     private lateinit var locationManager: FineLocationManager
 
@@ -861,7 +859,7 @@ class MainFragment : Fragment(R.layout.fragment_main),
         val view = view ?: return
 
         lifecycleScope.launch {
-            soundFx.play(resources.getIdentifier("plop" + random.nextInt(4), "raw", ctx.packageName))
+            soundFx.play(resources.getIdentifier("plop" + Random.nextInt(4), "raw", ctx.packageName))
         }
 
         val root = activity.window.decorView as ViewGroup

--- a/app/src/main/java/de/westnordost/streetcomplete/map/TangramPinsSpriteSheet.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/TangramPinsSpriteSheet.kt
@@ -9,7 +9,6 @@ import de.westnordost.streetcomplete.BuildConfig
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.ceil

--- a/app/src/main/java/de/westnordost/streetcomplete/map/tangram/KtMapController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/tangram/KtMapController.kt
@@ -19,7 +19,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.util.*
 import kotlinx.coroutines.*
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AAddLocalizedNameForm.kt
@@ -15,7 +15,7 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.toObject
 import de.westnordost.streetcomplete.util.AdapterDataChangedWatcher
 import de.westnordost.streetcomplete.util.Serializer
-import java.util.*
+import java.util.Queue
 import javax.inject.Inject
 
 abstract class AAddLocalizedNameForm<T> : AbstractQuestFormAnswerFragment<T>() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AGroupedImageListQuestAnswerFragment.kt
@@ -16,7 +16,7 @@ import de.westnordost.streetcomplete.view.image_select.GroupableDisplayItem
 import de.westnordost.streetcomplete.view.image_select.GroupedImageSelectAdapter
 import kotlinx.android.synthetic.main.fragment_quest_answer.*
 import kotlinx.android.synthetic.main.quest_generic_list.*
-import java.util.*
+import java.util.LinkedList
 import kotlin.math.max
 
 /**

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -35,7 +35,7 @@ import de.westnordost.streetcomplete.ktx.isSomeKindOfShop
 import de.westnordost.streetcomplete.quests.shop_type.ShopGoneDialog
 import kotlinx.android.synthetic.main.fragment_quest_answer.*
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.FutureTask
 import javax.inject.Inject
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AddLocalizedNameAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AddLocalizedNameAdapter.kt
@@ -18,7 +18,7 @@ import de.westnordost.streetcomplete.data.meta.Abbreviations
 import de.westnordost.streetcomplete.data.meta.AbbreviationsByLocale
 import de.westnordost.streetcomplete.util.DefaultTextWatcher
 import de.westnordost.streetcomplete.view.AutoCorrectAbbreviationsEditText
-import java.util.*
+import java.util.Locale
 
 /** Carries the data language tag + name in that language  */
 data class LocalizedName(var languageTag: String, var name: String)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.ktx.toList
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.FutureTask
 
 fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
@@ -16,7 +16,7 @@ import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.quests.road_name.RoadNameSuggestionsSource
 import de.westnordost.streetcomplete.util.TextChangedWatcher
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 class AddAddressStreetForm : AbstractQuestFormAnswerFragment<AddressStreetAnswer>() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/CompletedConstructionAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/CompletedConstructionAnswer.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.construction
 
-import java.util.*
+import java.time.LocalDate
 
 sealed class CompletedConstructionAnswer
 data class StateAnswer(val value : Boolean) : CompletedConstructionAnswer()
-data class OpeningDateAnswer(val date: Date) : CompletedConstructionAnswer()
+data class OpeningDateAnswer(val date: LocalDate) : CompletedConstructionAnswer()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedBuildingConstruction.kt
@@ -5,7 +5,7 @@ import de.westnordost.streetcomplete.data.meta.SURVEY_MARK_KEY
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import java.util.*
+import java.time.LocalDate
 
 class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
 
@@ -33,7 +33,7 @@ class MarkCompletedBuildingConstruction : OsmFilterQuestType<CompletedConstructi
                     changes.modify("building", value)
                     deleteTagsDescribingConstruction(changes)
                 } else {
-                    changes.addOrModify(SURVEY_MARK_KEY, Date().toCheckDateString())
+                    changes.addOrModify(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
                 }
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstructionForm.kt
@@ -2,9 +2,10 @@ package de.westnordost.streetcomplete.quests.construction
 
 import android.app.DatePickerDialog
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.toInstant
 import de.westnordost.streetcomplete.quests.AYesNoQuestAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
-import java.util.*
+import java.time.LocalDate
 
 class MarkCompletedConstructionForm : AYesNoQuestAnswerFragment<CompletedConstructionAnswer>() {
     override val otherAnswers = listOf(
@@ -12,16 +13,12 @@ class MarkCompletedConstructionForm : AYesNoQuestAnswerFragment<CompletedConstru
     )
 
     private fun setFinishDate() {
-        val tomorrow = Calendar.getInstance()
-        tomorrow.add(Calendar.DAY_OF_MONTH, 1)
-        val year = tomorrow.get(Calendar.YEAR)
-        val month = tomorrow.get(Calendar.MONTH)
-        val day = tomorrow.get(Calendar.DAY_OF_MONTH)
-        val dpd = DatePickerDialog(requireContext(), { _, yearSelected, monthSelected, dayOfMonthSelected ->
-            applyAnswer(OpeningDateAnswer(GregorianCalendar(yearSelected, monthSelected, dayOfMonthSelected).time))
-        }, year, month, day)
+        val tomorrow = LocalDate.now().plusDays(1)
+        val dpd = DatePickerDialog(requireContext(), { _, year, month, day ->
+            applyAnswer(OpeningDateAnswer(LocalDate.of(year, month + 1, day)))
+        }, tomorrow.year, tomorrow.monthValue - 1, tomorrow.dayOfMonth)
         dpd.setTitle(resources.getString(R.string.quest_construction_completion_date_title))
-        dpd.datePicker.minDate = tomorrow.timeInMillis
+        dpd.datePicker.minDate = tomorrow.toInstant().toEpochMilli()
         dpd.show()
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.SURVEY_MARK_KEY
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import java.util.*
+import java.time.LocalDate
 
 class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructionAnswer>() {
 
@@ -46,7 +46,7 @@ class MarkCompletedHighwayConstruction : OsmFilterQuestType<CompletedConstructio
                     changes.modify("highway", value)
                     deleteTagsDescribingConstruction(changes)
                 } else {
-                    changes.addOrModify(SURVEY_MARK_KEY, Date().toCheckDateString())
+                    changes.addOrModify(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
                 }
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.ktx.arrayOfNotNull
 import de.westnordost.streetcomplete.ktx.containsAnyKey
-import java.util.*
+import java.time.LocalDate
 import java.util.concurrent.FutureTask
 
 class CheckExistence(
@@ -87,7 +87,7 @@ class CheckExistence(
     override fun createForm() = CheckExistenceForm()
 
     override fun applyAnswerTo(answer: Unit, changes: StringMapChangesBuilder) {
-        changes.addOrModify(SURVEY_MARK_KEY, Date().toCheckDateString())
+        changes.addOrModify(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
         val otherCheckDateKeys = LAST_CHECK_DATE_KEYS.filterNot { it == SURVEY_MARK_KEY }
         for (otherCheckDateKey in otherCheckDateKeys) {
             changes.deleteIfExists(otherCheckDateKey)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
@@ -31,7 +31,6 @@ import kotlinx.android.synthetic.main.fragment_attach_photo.*
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.*
 
 class AttachPhotoFragment : Fragment() {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.kt
@@ -31,7 +31,7 @@ import kotlinx.android.synthetic.main.quest_buttonpanel_note_discussion.*
 import kotlinx.android.synthetic.main.quest_note_discussion_content.*
 import kotlinx.android.synthetic.main.quest_note_discussion_item.view.*
 import java.io.File
-import java.util.*
+import java.time.Instant
 import javax.inject.Inject
 
 class NoteDiscussionForm : AbstractQuestAnswerFragment<NoteAnswer>() {
@@ -140,7 +140,7 @@ class NoteDiscussionForm : AbstractQuestAnswerFragment<NoteAnswer>() {
         }
 
         override fun onBind(comment: NoteComment) {
-            val dateDescription = DateUtils.getRelativeTimeSpanString(comment.timestamp, Date().time, MINUTE_IN_MILLIS)
+            val dateDescription = DateUtils.getRelativeTimeSpanString(comment.timestamp, Instant.now().toEpochMilli(), MINUTE_IN_MILLIS)
             val userName = if (comment.user != null) comment.user.displayName else getString(R.string.quest_noteDiscussion_anonymous)
 
             val commentActionResourceId = comment.action.actionResourceId

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -1,7 +1,9 @@
 package de.westnordost.streetcomplete.quests.opening_hours.model
 
-import java.text.DateFormat
-import java.util.*
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
 
 /** A time range from [start,end). */
 class TimeRange(minutesStart: Int, minutesEnd: Int, val isOpenEnded: Boolean = false)
@@ -39,9 +41,7 @@ class TimeRange(minutesStart: Int, minutesEnd: Int, val isOpenEnded: Boolean = f
     override fun toString() = toStringUsing(Locale.GERMANY, "-")
 
     private fun timeOfDayToString(locale: Locale, minutes: Int): String {
-        val cal = GregorianCalendar()
-        cal.set(Calendar.HOUR_OF_DAY, minutes / 60)
-        cal.set(Calendar.MINUTE, minutes % 60)
-        return DateFormat.getTimeInstance(DateFormat.SHORT, locale).format(cal.time)
+        val formatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
+        return formatter.format(LocalTime.ofSecondOfDay(minutes * 60L))
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/model/TimeRange.kt
@@ -1,8 +1,7 @@
 package de.westnordost.streetcomplete.quests.opening_hours.model
 
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import java.text.DateFormat
+import java.time.*
 import java.util.Locale
 
 /** A time range from [start,end). */
@@ -41,7 +40,10 @@ class TimeRange(minutesStart: Int, minutesEnd: Int, val isOpenEnded: Boolean = f
     override fun toString() = toStringUsing(Locale.GERMANY, "-")
 
     private fun timeOfDayToString(locale: Locale, minutes: Int): String {
-        val formatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
-        return formatter.format(LocalTime.ofSecondOfDay(minutes * 60L))
+        val todayAt = LocalDateTime.of(LocalDate.now(), LocalTime.ofSecondOfDay(minutes * 60L))
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+        return DateFormat.getTimeInstance(DateFormat.SHORT, locale).format(todayAt)
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFeeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_fee/AddParkingFeeForm.kt
@@ -20,7 +20,6 @@ import de.westnordost.streetcomplete.util.Serializer
 import kotlinx.android.synthetic.main.fragment_quest_answer.*
 import kotlinx.android.synthetic.main.quest_buttonpanel_yes_no.*
 import kotlinx.android.synthetic.main.quest_fee_hours.*
-import java.util.*
 import javax.inject.Inject
 
 class AddParkingFeeForm : AbstractQuestFormAnswerFragment<FeeAnswer>() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/WeekdaysTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/WeekdaysTimes.kt
@@ -1,7 +1,7 @@
 package de.westnordost.streetcomplete.quests.postbox_collection_times
 
 import de.westnordost.streetcomplete.quests.opening_hours.model.Weekdays
-import java.util.*
+import java.util.Locale
 
 data class WeekdaysTimes(var weekdays: Weekdays, var minutesList: MutableList<Int>) {
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.meta.SURVEY_MARK_KEY
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import java.util.*
+import java.time.LocalDate
 
 class CheckShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
@@ -34,7 +34,7 @@ class CheckShopType : OsmFilterQuestType<ShopTypeAnswer>() {
         }
         when (answer) {
             is IsShopVacant -> {
-                changes.addOrModify(SURVEY_MARK_KEY, Date().toCheckDateString())
+                changes.addOrModify(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
             }
             is ShopType -> {
                 changes.deleteIfExists("disused:shop")

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.ktx.containsAny
-import java.util.*
+import java.time.LocalDate
 
 class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
@@ -48,7 +48,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
         }
         when (answer) {
             is IsShopVacant -> {
-                changes.addOrModify(SURVEY_MARK_KEY, Date().toCheckDateString())
+                changes.addOrModify(SURVEY_MARK_KEY, LocalDate.now().toCheckDateString())
             }
             is ShopType -> {
                 changes.deleteIfExists("disused:shop")

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/OAuthFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/OAuthFragment.kt
@@ -19,7 +19,7 @@ import oauth.signpost.OAuthConsumer
 import oauth.signpost.OAuthProvider
 import oauth.signpost.exception.OAuthCommunicationException
 import oauth.signpost.exception.OAuthExpectationFailedException
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider

--- a/app/src/main/java/de/westnordost/streetcomplete/user/CircularFlagView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/CircularFlagView.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewOutlineProvider
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.getYamlObject
-import java.util.*
+import java.util.Locale
 import kotlin.math.min
 
 /** Show a flag of a country in a circle */

--- a/app/src/main/java/de/westnordost/streetcomplete/user/CountryInfoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/CountryInfoFragment.kt
@@ -15,7 +15,7 @@ import androidx.core.view.isGone
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.tryStartActivity
 import kotlinx.android.synthetic.main.fragment_country_info_dialog.*
-import java.util.*
+import java.util.Locale
 import kotlin.math.min
 import kotlin.math.pow
 

--- a/app/src/main/java/de/westnordost/streetcomplete/user/LoginFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/LoginFragment.kt
@@ -11,12 +11,12 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.lifecycle.lifecycleScope
 import de.westnordost.osmapi.user.Permission
+import de.westnordost.osmapi.user.PermissionsApi
 import de.westnordost.streetcomplete.BackPressedListener
 import de.westnordost.streetcomplete.HasTitle
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.OsmApiModule
-import de.westnordost.streetcomplete.data.PermissionsApi
 import de.westnordost.streetcomplete.data.UnsyncedChangesCountSource
 import de.westnordost.streetcomplete.data.user.UserController
 import de.westnordost.streetcomplete.ktx.childFragmentManagerOrNull

--- a/app/src/main/java/de/westnordost/streetcomplete/user/ProfileFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/user/ProfileFragment.kt
@@ -21,7 +21,7 @@ import de.westnordost.streetcomplete.ktx.tryStartActivity
 import kotlinx.android.synthetic.main.fragment_profile.*
 import kotlinx.coroutines.*
 import java.io.File
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 /** Shows the user profile: username, avatar, star count and a hint regarding unpublished changes */

--- a/app/src/main/java/de/westnordost/streetcomplete/util/CrashReportExceptionHandler.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/CrashReportExceptionHandler.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.ktx.toast
 import java.io.IOException
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/de/westnordost/streetcomplete/util/GeoUri.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/GeoUri.kt
@@ -2,7 +2,7 @@ package de.westnordost.streetcomplete.util
 
 import android.net.Uri
 import androidx.core.net.toUri
-import java.util.*
+import de.westnordost.streetcomplete.ktx.format
 
 fun parseGeoUri(uri: Uri): GeoLocation? {
     if (uri.scheme != "geo") return null
@@ -22,8 +22,10 @@ fun parseGeoUri(uri: Uri): GeoLocation? {
 }
 
 fun buildGeoUri(latitude: Double, longitude: Double, zoom: Float? = null): Uri {
-    val zoomStr = if (zoom != null) "?z=$zoom" else ""
-    val geoUri = Formatter(Locale.US).format("geo:%.5f,%.5f%s", latitude, longitude, zoomStr).toString()
+    val z = if (zoom != null) "?z=$zoom" else ""
+    val lat = latitude.format(5)
+    val lon = longitude.format(5)
+    val geoUri = "geo:$lat,$lon$z"
     return geoUri.toUri()
 }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpressionTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFilterExpressionTest.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.testutils.on
 
 import org.junit.Assert.*
-import java.util.*
+import java.util.EnumSet
 
 class ElementFilterExpressionTest {
     // Tests for toOverpassQLString are in FiltersParserTest

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersTestUtils.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/ElementFiltersTestUtils.kt
@@ -2,18 +2,14 @@ package de.westnordost.streetcomplete.data.elementfilter
 
 import de.westnordost.streetcomplete.testutils.node
 import de.westnordost.streetcomplete.data.elementfilter.filters.ElementFilter
+import de.westnordost.streetcomplete.ktx.toEpochMilli
 
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 /** Returns the date x days in the past */
-fun dateDaysAgo(daysAgo: Float): Date {
-    val cal: Calendar = Calendar.getInstance()
-    cal.add(Calendar.SECOND, -(daysAgo * 24 * 60 * 60).toInt())
-    return cal.time
-}
+fun dateDaysAgo(daysAgo: Float): LocalDate =
+    LocalDateTime.now().minusHours((daysAgo * 24).toLong()).toLocalDate()
 
-fun ElementFilter.matches(tags: Map<String,String>, date: Date? = null): Boolean =
-    matches(node(tags = tags, date = date))
-
-val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+fun ElementFilter.matches(tags: Map<String,String>, date: LocalDate? = null): Boolean =
+    matches(node(tags = tags, timestamp = date?.toEpochMilli()))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterOrEqualThanTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import de.westnordost.streetcomplete.data.elementfilter.DATE_FORMAT
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.LocalDate
 
 class HasDateTagGreaterOrEqualThanTest {
-    private val date = DATE_FORMAT.parse("2000-11-11")!!
+    private val date = LocalDate.of(2000,11,11)
 
     @Test fun matches() {
         val c = HasDateTagGreaterOrEqualThan("check_date", FixedDate(date))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagGreaterThanTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import de.westnordost.streetcomplete.data.elementfilter.DATE_FORMAT
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.LocalDate
 
 class HasDateTagGreaterThanTest {
-    private val date = DATE_FORMAT.parse("2000-11-11")!!
+    private val date = LocalDate.of(2000,11,11)
 
     @Test fun matches() {
         val c = HasDateTagGreaterThan("check_date", FixedDate(date))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessOrEqualThanTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import de.westnordost.streetcomplete.data.elementfilter.DATE_FORMAT
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.LocalDate
 
 class HasDateTagLessOrEqualThanTest {
-    private val date = DATE_FORMAT.parse("2000-11-11")!!
+    private val date = LocalDate.of(2000,11,11)
 
     @Test fun matches() {
         val c = HasDateTagLessOrEqualThan("check_date", FixedDate(date))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThanTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/elementfilter/filters/HasDateTagLessThanTest.kt
@@ -1,12 +1,12 @@
 package de.westnordost.streetcomplete.data.elementfilter.filters
 
-import de.westnordost.streetcomplete.data.elementfilter.DATE_FORMAT
 import de.westnordost.streetcomplete.data.elementfilter.matches
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.LocalDate
 
 class HasDateTagLessThanTest {
-    private val date = DATE_FORMAT.parse("2000-11-11")!!
+    private val date = LocalDate.of(2000,11,11)
 
     @Test fun matches() {
         val c = HasDateTagLessThan("check_date", FixedDate(date))

--- a/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/meta/ResurveyUtilsTest.kt
@@ -7,22 +7,16 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.ktx.containsExactlyInAnyOrder
 import org.junit.Assert.*
 import org.junit.Test
-import java.util.*
-import java.util.Calendar.MILLISECOND
+import java.time.LocalDate
 
 
 class ResurveyUtilsTest {
     @Test fun toCheckDateString() {
-        val cal = Calendar.getInstance()
-        cal.set(2007, 11, 8)
-        assertEquals("2007-12-08", cal.time.toCheckDateString())
+        assertEquals("2007-12-08", LocalDate.of(2007, 12, 8).toCheckDateString())
     }
 
     @Test fun fromCheckDateString() {
-        val cal = Calendar.getInstance()
-        cal.set(2007, 11, 8, 0, 0, 0)
-        cal.set(MILLISECOND, 0)
-        assertEquals(cal.time, "2007-12-08".toCheckDate())
+        assertEquals(LocalDate.of(2007, 12, 8), "2007-12-08".toCheckDate())
     }
 
     @Test fun `updateWithCheckDate adds new tag`() {
@@ -51,7 +45,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes
 
         assertEquals(listOf(
-            StringMapEntryAdd("check_date:key", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:key", LocalDate.now().toCheckDateString())
         ), changes)
     }
 
@@ -61,7 +55,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes
 
         assertEquals(listOf(
-            StringMapEntryModify("check_date:key", "2000-11-11", Date().toCheckDateString())
+            StringMapEntryModify("check_date:key", "2000-11-11", LocalDate.now().toCheckDateString())
         ), changes)
     }
 
@@ -126,7 +120,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes.toSet()
 
         assertTrue(changes.containsExactlyInAnyOrder(listOf(
-            StringMapEntryModify("check_date:key", "2000-11-01", Date().toCheckDateString()),
+            StringMapEntryModify("check_date:key", "2000-11-01", LocalDate.now().toCheckDateString()),
             StringMapEntryDelete("key:check_date", "2000-11-02"),
             StringMapEntryDelete("key:lastcheck", "2000-11-03"),
             StringMapEntryDelete("lastcheck:key", "2000-11-04"),
@@ -141,7 +135,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes
 
         assertEquals(listOf(
-            StringMapEntryAdd("check_date:key", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:key", LocalDate.now().toCheckDateString())
         ), changes)
     }
 
@@ -151,7 +145,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes
 
         assertEquals(listOf(
-            StringMapEntryModify("check_date:key", "2000-11-11", Date().toCheckDateString())
+            StringMapEntryModify("check_date:key", "2000-11-11", LocalDate.now().toCheckDateString())
         ), changes)
     }
 
@@ -168,7 +162,7 @@ class ResurveyUtilsTest {
         val changes = builder.create().changes.toSet()
 
         assertTrue(changes.containsExactlyInAnyOrder(listOf(
-            StringMapEntryModify("check_date:key", "2000-11-01", Date().toCheckDateString()),
+            StringMapEntryModify("check_date:key", "2000-11-01", LocalDate.now().toCheckDateString()),
             StringMapEntryDelete("key:check_date", "2000-11-02"),
             StringMapEntryDelete("key:lastcheck", "2000-11-03"),
             StringMapEntryDelete("lastcheck:key", "2000-11-04"),

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManagerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/edits/upload/changesets/OpenQuestChangesetsManagerTest.kt
@@ -12,7 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.*
-import java.util.*
+import java.util.Locale
 
 class OpenQuestChangesetsManagerTest {
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddBusStopShelterTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddBusStopShelterTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.BusStopShelterAnswer
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class AddBusStopShelterTest {
 
@@ -23,7 +23,7 @@ class AddBusStopShelterTest {
         questType.verifyAnswer(
             mapOf("shelter" to "yes"),
             BusStopShelterAnswer.SHELTER,
-            StringMapEntryAdd("check_date:shelter", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:shelter", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -38,7 +38,7 @@ class AddBusStopShelterTest {
         questType.verifyAnswer(
             mapOf("shelter" to "no"),
             BusStopShelterAnswer.NO_SHELTER,
-            StringMapEntryAdd("check_date:shelter", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:shelter", LocalDate.now().toCheckDateString())
         )
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddCrossingTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddCrossingTypeTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.quests.crossing_type.AddCrossingType
 import de.westnordost.streetcomplete.quests.crossing_type.CrossingType.*
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class AddCrossingTypeTest {
 
@@ -41,19 +41,19 @@ class AddCrossingTypeTest {
         questType.verifyAnswer(
             mapOf("crossing" to "zebra"),
             MARKED,
-            StringMapEntryAdd("check_date:crossing", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:crossing", LocalDate.now().toCheckDateString())
         )
 
         questType.verifyAnswer(
             mapOf("crossing" to "marked"),
             MARKED,
-            StringMapEntryAdd("check_date:crossing", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:crossing", LocalDate.now().toCheckDateString())
         )
 
         questType.verifyAnswer(
             mapOf("crossing" to "uncontrolled"),
             MARKED,
-            StringMapEntryAdd("check_date:crossing", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:crossing", LocalDate.now().toCheckDateString())
         )
 
         questType.verifyAnswer(

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddCyclewayTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddCyclewayTest.kt
@@ -7,13 +7,15 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.ktx.toEpochMilli
 import de.westnordost.streetcomplete.quests.bikeway.*
 import de.westnordost.streetcomplete.quests.bikeway.Cycleway.*
 import de.westnordost.streetcomplete.util.translate
 import de.westnordost.streetcomplete.testutils.way
 import org.junit.Assert.*
 import org.junit.Test
-import java.util.*
+import java.time.Instant
+import java.time.LocalDate
 
 class AddCyclewayTest {
 
@@ -148,7 +150,7 @@ class AddCyclewayTest {
             way(1L, listOf(1,2,3), mapOf(
                 "highway" to "primary",
                 "cycleway" to "track"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         ))
         assertEquals(0, questType.getApplicableElements(mapData).toList().size)
     }
@@ -159,7 +161,7 @@ class AddCyclewayTest {
                 "highway" to "primary",
                 "cycleway" to "track",
                 "check_date:cycleway" to "2001-01-01"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         ))
         assertEquals(1, questType.getApplicableElements(mapData).toList().size)
     }
@@ -170,7 +172,7 @@ class AddCyclewayTest {
                 "highway" to "primary",
                 "cycleway" to "whatsthis",
                 "check_date:cycleway" to "2001-01-01"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         ))
         assertEquals(0, questType.getApplicableElements(mapData).toList().size)
     }
@@ -489,7 +491,7 @@ class AddCyclewayTest {
             mapOf("cycleway:both" to "track"),
             bothSidesAnswer(TRACK),
             StringMapEntryModify("cycleway:both","track", "track"),
-            StringMapEntryAdd("check_date:cycleway", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:cycleway", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -498,7 +500,7 @@ class AddCyclewayTest {
             mapOf("cycleway:both" to "track", "check_date:cycleway" to "2000-11-11"),
             bothSidesAnswer(TRACK),
             StringMapEntryModify("cycleway:both","track", "track"),
-            StringMapEntryModify("check_date:cycleway", "2000-11-11", Date().toCheckDateString())
+            StringMapEntryModify("check_date:cycleway", "2000-11-11", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -528,25 +530,25 @@ class AddCyclewayTest {
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway" to "track"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertTrue(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:left" to "track"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertTrue(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:right" to "track"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertTrue(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:both" to "track"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
     }
 
@@ -559,7 +561,7 @@ class AddCyclewayTest {
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway" to "track"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         )!!)
     }
 
@@ -568,25 +570,25 @@ class AddCyclewayTest {
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:left" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:right" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:both" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
     }
 
@@ -595,25 +597,25 @@ class AddCyclewayTest {
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway" to "separate"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:left" to "separate"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:right" to "separate"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:both" to "separate"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
     }
 
@@ -624,28 +626,28 @@ class AddCyclewayTest {
                 "highway" to "unclassified",
                 "cycleway" to "lane",
                 "cycleway:lane" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:left" to "lane",
                 "cycleway:left:lane" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:right" to "lane",
                 "cycleway:right:lane" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
         assertFalse(questType.isApplicableTo(
             way(tags = mapOf(
                 "highway" to "unclassified",
                 "cycleway:both" to "lane",
                 "cycleway:both:lane" to "something"
-            ), date = "2000-10-10".toCheckDate())
+            ), timestamp = "2000-10-10".toCheckDate()?.toEpochMilli())
         )!!)
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddParkingFeeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddParkingFeeTest.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.quests.opening_hours.model.*
 import de.westnordost.streetcomplete.quests.parking_fee.*
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class AddParkingFeeTest {
 
@@ -77,7 +77,7 @@ class AddParkingFeeTest {
             mapOf("fee" to "yes"),
             HasFeeExceptAtHours(openingHours),
             StringMapEntryAdd("fee:conditional", "no @ ($openingHoursString)"),
-            StringMapEntryAdd("check_date:fee", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:fee", LocalDate.now().toCheckDateString())
         )
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/AddRecyclingContainerMaterialsTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/AddRecyclingContainerMaterialsTest.kt
@@ -13,7 +13,8 @@ import de.westnordost.streetcomplete.quests.recycling_material.RecyclingMaterial
 import de.westnordost.streetcomplete.util.translate
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.util.*
+import java.time.Instant
+import java.time.LocalDate
 
 class AddRecyclingContainerMaterialsTest {
 
@@ -48,7 +49,7 @@ class AddRecyclingContainerMaterialsTest {
                 "check_date:recycling" to "2001-01-01",
                 "recycling:plastic_packaging" to "yes",
                 "recycling:something_else" to "no"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         ))
         assertEquals(1, questType.getApplicableElements(mapData).toList().size)
     }
@@ -60,7 +61,7 @@ class AddRecyclingContainerMaterialsTest {
                 "recycling_type" to "container",
                 "check_date:recycling" to "2001-01-01",
                 "recycling:something_else" to "yes"
-            ), date = Date())
+            ), timestamp = Instant.now().toEpochMilli())
         ))
         assertEquals(0, questType.getApplicableElements(mapData).toList().size)
     }
@@ -220,7 +221,7 @@ class AddRecyclingContainerMaterialsTest {
             RecyclingMaterials(listOf(CLOTHES, PAPER)),
             StringMapEntryModify("recycling:paper", "yes", "yes"),
             StringMapEntryModify("recycling:clothes", "yes", "yes"),
-            StringMapEntryAdd("check_date:recycling", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:recycling", LocalDate.now().toCheckDateString())
         )
     }
 

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/existence/CheckExistenceTest.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryMo
 import de.westnordost.streetcomplete.testutils.mock
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class CheckExistenceTest {
     private val questType = CheckExistence(mock())
@@ -15,7 +15,7 @@ class CheckExistenceTest {
     @Test fun `apply answer adds check date`() {
         questType.verifyAnswer(
             Unit,
-            StringMapEntryAdd("check_date", Date().toCheckDateString())
+            StringMapEntryAdd("check_date", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -29,7 +29,7 @@ class CheckExistenceTest {
                 "survey_date" to "d"
             ),
             Unit,
-            StringMapEntryModify("check_date", "1", Date().toCheckDateString()),
+            StringMapEntryModify("check_date", "1", LocalDate.now().toCheckDateString()),
             StringMapEntryDelete("lastcheck", "a"),
             StringMapEntryDelete("last_checked", "b"),
             StringMapEntryDelete("survey:date", "c"),

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursTest.kt
@@ -9,13 +9,14 @@ import de.westnordost.streetcomplete.data.meta.toCheckDate
 import de.westnordost.streetcomplete.data.meta.toCheckDateString
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
+import de.westnordost.streetcomplete.ktx.toEpochMilli
 import de.westnordost.streetcomplete.quests.opening_hours.model.*
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import de.westnordost.streetcomplete.testutils.mock
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 
 class AddOpeningHoursTest {
@@ -41,7 +42,7 @@ class AddOpeningHoursTest {
         questType.verifyAnswer(
             mapOf("opening_hours" to "\"oh\""),
             DescribeOpeningHours("oh"),
-            StringMapEntryAdd("check_date:opening_hours", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:opening_hours", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -79,7 +80,7 @@ class AddOpeningHoursTest {
         questType.verifyAnswer(
             mapOf("opening_hours" to "24/7"),
             AlwaysOpen,
-            StringMapEntryAdd("check_date:opening_hours", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:opening_hours", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -142,33 +143,41 @@ class AddOpeningHoursTest {
                     })
                 })
             )),
-            StringMapEntryAdd("check_date:opening_hours", Date().toCheckDateString())
+            StringMapEntryAdd("check_date:opening_hours", LocalDate.now().toCheckDateString())
         )
     }
 
     @Test fun `isApplicableTo returns false for unknown places`() {
         assertFalse(questType.isApplicableTo(node(
-                tags = mapOf("whatisthis" to "something")
+            tags = mapOf("whatisthis" to "something")
         )))
     }
 
     @Test fun `isApplicableTo returns true for known places`() {
         assertTrue(questType.isApplicableTo(node(
-                tags = mapOf("shop" to "sports", "name" to "Atze's Angelladen")
+            tags = mapOf("shop" to "sports", "name" to "Atze's Angelladen")
         )))
     }
 
     @Test fun `isApplicableTo returns true if the opening hours cannot be parsed`() {
         assertTrue(questType.isApplicableTo(node(
-                tags = mapOf("shop" to "supermarket", "name" to "Supi", "opening_hours" to "maybe open maybe closed who knows"),
-                date = "2000-11-11".toCheckDate()
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours" to "maybe open maybe closed who knows"
+            ),
+            timestamp = "2000-11-11".toCheckDate()?.toEpochMilli()
         )))
     }
 
     @Test fun `isApplicableTo returns false if the opening hours are not supported`() {
         assertFalse(questType.isApplicableTo(node(
-                tags = mapOf("shop" to "supermarket", "name" to "Supi", "opening_hours" to "1998 Mo-Fr 18:00-20:00"),
-                date = "2000-11-11".toCheckDate()
+            tags = mapOf(
+                "shop" to "supermarket",
+                "name" to "Supi",
+                "opening_hours" to "1998 Mo-Fr 18:00-20:00"
+            ),
+            timestamp = "2000-11-11".toCheckDate()?.toEpochMilli()
         )))
     }
 }

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopTypeTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/shop_type/CheckShopTypeTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class CheckShopTypeTest {
     private val questType = CheckShopType()
@@ -14,7 +14,7 @@ class CheckShopTypeTest {
     @Test fun `apply shop vacant answer`() {
         questType.verifyAnswer(
             IsShopVacant,
-            StringMapEntryAdd("check_date", Date().toCheckDateString())
+            StringMapEntryAdd("check_date", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -22,7 +22,7 @@ class CheckShopTypeTest {
         questType.verifyAnswer(
             mapOf("check_date" to "already set"),
             IsShopVacant,
-            StringMapEntryModify("check_date", "already set", Date().toCheckDateString())
+            StringMapEntryModify("check_date", "already set", LocalDate.now().toCheckDateString())
         )
     }
 
@@ -35,7 +35,7 @@ class CheckShopTypeTest {
                 "survey_date" to "d"
             ),
             IsShopVacant,
-            StringMapEntryAdd("check_date", Date().toCheckDateString()),
+            StringMapEntryAdd("check_date", LocalDate.now().toCheckDateString()),
             StringMapEntryDelete("lastcheck", "a"),
             StringMapEntryDelete("last_checked", "b"),
             StringMapEntryDelete("survey:date", "c"),

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/steps_ramp/AddStepsRampTest.kt
@@ -6,7 +6,7 @@ import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDe
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
 import de.westnordost.streetcomplete.quests.verifyAnswer
 import org.junit.Test
-import java.util.*
+import java.time.LocalDate
 
 class AddStepsRampTest {
 
@@ -50,7 +50,7 @@ class AddStepsRampTest {
                 wheelchairRamp = WheelchairRampStatus.YES
             ),
             StringMapEntryAdd("ramp:wheelchair", "yes"),
-            StringMapEntryAdd("check_date:ramp", Date().toCheckDateString()),
+            StringMapEntryAdd("check_date:ramp", LocalDate.now().toCheckDateString()),
         )
     }
 
@@ -84,7 +84,7 @@ class AddStepsRampTest {
             StringMapEntryModify("ramp:bicycle", "yes", "yes"),
             StringMapEntryModify("ramp:stroller", "no", "yes"),
             StringMapEntryModify("ramp:wheelchair", "automatic", "yes"),
-            StringMapEntryAdd("check_date:ramp", Date().toCheckDateString()),
+            StringMapEntryAdd("check_date:ramp", LocalDate.now().toCheckDateString()),
         )
     }
 
@@ -119,7 +119,7 @@ class AddStepsRampTest {
                 strollerRamp = false,
                 wheelchairRamp = WheelchairRampStatus.NO
             ),
-            StringMapEntryAdd("check_date:ramp", Date().toCheckDateString()),
+            StringMapEntryAdd("check_date:ramp", LocalDate.now().toCheckDateString()),
             StringMapEntryDelete("ramp:bicycle", "yes")
         )
     }

--- a/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/testutils/TestDataShortcuts.kt
@@ -19,7 +19,6 @@ import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.TestQuestTypeA
 import de.westnordost.streetcomplete.data.user.User
 import java.lang.System.currentTimeMillis
-import java.util.*
 
 fun p(lat: Double = 0.0, lon: Double = 0.0) = LatLon(lat, lon)
 
@@ -28,24 +27,24 @@ fun node(
     pos: LatLon = p(),
     tags: Map<String, String> = emptyMap(),
     version: Int = 1,
-    date: Date? = null
-) = Node(id, pos, tags, version, date?.time ?: currentTimeMillis())
+    timestamp: Long? = null
+) = Node(id, pos, tags, version, timestamp ?: currentTimeMillis())
 
 fun way(
     id: Long = 1,
     nodes: List<Long> = listOf(),
     tags: Map<String, String> = emptyMap(),
     version: Int = 1,
-    date: Date? = null
-) = Way(id, nodes, tags, version, date?.time ?: currentTimeMillis())
+    timestamp: Long? = null
+) = Way(id, nodes, tags, version, timestamp ?: currentTimeMillis())
 
 fun rel(
     id: Long = 1,
     members: List<RelationMember> = listOf(),
     tags: Map<String, String> = emptyMap(),
     version: Int = 1,
-    date: Date? = null
-) = Relation(id, members.toMutableList(), tags, version, date?.time ?: currentTimeMillis())
+    timestamp: Long? = null
+) = Relation(id, members.toMutableList(), tags, version, timestamp ?: currentTimeMillis())
 
 fun member(
     type: ElementType = ElementType.NODE,

--- a/buildSrc/src/main/java/AUpdateFromPOEditorTask.kt
+++ b/buildSrc/src/main/java/AUpdateFromPOEditorTask.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.Input
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.*
+import java.util.Locale
 
 /** Base task class to pull translations and other info from POEditor crowd translation platform */
 abstract class AUpdateFromPOEditorTask : DefaultTask() {

--- a/buildSrc/src/main/java/UpdateAppTranslationsTask.kt
+++ b/buildSrc/src/main/java/UpdateAppTranslationsTask.kt
@@ -2,7 +2,7 @@
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
-import java.util.*
+import java.util.Locale
 
 /** Update the Android string resources (translations) for all the given language codes */
 open class UpdateAppTranslationsTask : AUpdateFromPOEditorTask() {

--- a/buildSrc/src/main/java/UpdateStoreDescriptionsTask.kt
+++ b/buildSrc/src/main/java/UpdateStoreDescriptionsTask.kt
@@ -3,7 +3,7 @@ import com.beust.klaxon.Parser
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
-import java.util.*
+import java.util.Locale
 
 /** Update the metadata that contain the store descriptions for the app (for F-Droid) */
 open class UpdateStoreDescriptionsTask : AUpdateFromPOEditorTask() {

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -1,6 +1,4 @@
-import java.util.*
-
-
+import java.util.Locale
 
 // Java (and thus also Android) uses some old iso (language) codes. F.e. id -> in etc.
 // so the localized files also need to use the old iso codes


### PR DESCRIPTION
Use new osmapi version that parses with Java 8 time APIs and also use Java 8 time classes everyhwere.

Measurements with my phone (Samsung S10e) indicate a performance improvement of the map data download (i.e. download time + parsing time) by about 45%, which verifies the measurements shown at https://github.com/streetcomplete/StreetComplete/discussions/2740

Of course, downloading and parsing the OSM data is only one step of the whole download process which also involves persisting that data into a local database, scanning the result for quests and also persisting those. So in total, it only reduces download time by 15%.

@FloEdelmann  I did not directly commit to your branch because I thought you might want to have a look at it first. Otherwise, it can be merged directly.